### PR TITLE
Rewrite how spans are stored

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -30,6 +30,7 @@
     ; Test
     (alcotest :with-test)
     (junit :with-test)
+    (qcheck-core :with-test)
     (omnomnom :with-test)
 
     ; Documentation generation

--- a/esy.json
+++ b/esy.json
@@ -28,6 +28,7 @@
     "@opam/reason": "*",
     "@opam/alcotest": "*",
     "@opam/junit": "*",
+    "@opam/qcheck-core": "*",
     "@opam/omnomnom": "*",
     "@opam/odoc": "*",
     "@opam/ocamlformat": "*",

--- a/illuaminate.opam
+++ b/illuaminate.opam
@@ -19,6 +19,7 @@ depends: [
   "reason" {build}
   "alcotest" {with-test}
   "junit" {with-test}
+  "qcheck-core" {with-test}
   "omnomnom" {with-test}
   "odoc" {with-doc}
   "ocamlformat" {dev}

--- a/src/bin/cli/github_types.ml
+++ b/src/bin/cli/github_types.ml
@@ -155,12 +155,12 @@ module Consts = struct
 
   (** Convert an error into an annotation. *)
   let to_annotation ({ span; message; tag; details } : Error.Error.t) : annotation =
-    let same_line = span.start_line = span.finish_line in
-    { path = span.filename.name;
-      start_line = span.start_line;
-      end_line = span.finish_line;
-      start_column = (if same_line then Some span.start_col else None);
-      end_column = (if same_line then Some span.finish_col else None);
+    let same_line = Span.start_line.get span = Span.finish_line.get span in
+    { path = (Span.filename span).name;
+      start_line = Span.start_line.get span;
+      end_line = Span.finish_line.get span;
+      start_column = (if same_line then Some (Span.start_col.get span) else None);
+      end_column = (if same_line then Some (Span.finish_col.get span) else None);
       annotation_level =
         ( match tag.level with
         | Critical | Error -> Failure

--- a/src/bin/cli/github_types.ml
+++ b/src/bin/cli/github_types.ml
@@ -155,10 +155,10 @@ module Consts = struct
 
   (** Convert an error into an annotation. *)
   let to_annotation ({ span; message; tag; details } : Error.Error.t) : annotation =
-    let same_line = Span.start_line.get span = Span.finish_line.get span in
+    let same_line = Span.start_line span = Span.finish_line span in
     { path = (Span.filename span).name;
-      start_line = Span.start_line.get span;
-      end_line = Span.finish_line.get span;
+      start_line = Span.start_line span;
+      end_line = Span.finish_line span;
       start_column = (if same_line then Some (Span.start_col.get span) else None);
       end_column = (if same_line then Some (Span.finish_col.get span) else None);
       annotation_level =

--- a/src/bin/config_format/illuaminateConfigFormat.ml
+++ b/src/bin/config_format/illuaminateConfigFormat.ml
@@ -100,16 +100,16 @@ let doc_options_term =
            | [] -> Some (Buffer.contents out)
            | Lex_template.Raw x :: xs -> Buffer.add_string out x; go xs
            | Key "path" :: xs ->
-               span.filename.path
+               (Span.filename span).path
                |> CCOpt.flat_map (Fpath.relativize ~root)
                |> CCOpt.flat_map (fun x ->
                       Fpath.to_string x |> Buffer.add_string out;
                       go xs)
            | Key ("line" | "sline") :: xs ->
-               string_of_int span.start_line |> Buffer.add_string out;
+               Span.start_line.get span |> string_of_int |> Buffer.add_string out;
                go xs
            | Key "eline" :: xs ->
-               string_of_int span.finish_line |> Buffer.add_string out;
+               Span.finish_line.get span |> string_of_int |> Buffer.add_string out;
                go xs
            | Key "commit" :: xs -> (
              match Lazy.force git_commit with

--- a/src/bin/config_format/illuaminateConfigFormat.ml
+++ b/src/bin/config_format/illuaminateConfigFormat.ml
@@ -106,10 +106,10 @@ let doc_options_term =
                       Fpath.to_string x |> Buffer.add_string out;
                       go xs)
            | Key ("line" | "sline") :: xs ->
-               Span.start_line.get span |> string_of_int |> Buffer.add_string out;
+               Span.start_line span |> string_of_int |> Buffer.add_string out;
                go xs
            | Key "eline" :: xs ->
-               Span.finish_line.get span |> string_of_int |> Buffer.add_string out;
+               Span.finish_line span |> string_of_int |> Buffer.add_string out;
                go xs
            | Key "commit" :: xs -> (
              match Lazy.force git_commit with

--- a/src/bin/lsp/lint.ml
+++ b/src/bin/lsp/lint.ml
@@ -6,7 +6,7 @@ open Lsp_convert
 open Syntax
 module D = IlluaminateData
 
-let fname p = (Syntax.Spanned.program p).filename
+let fname p = Syntax.Spanned.program p |> Span.filename
 
 let diagnostic ~tag ~span ?relatedInformation ?tags message =
   Diagnostic.create ~range:(range span) ~severity:(tag_severity tag) ~code:(tag_code tag)
@@ -24,7 +24,7 @@ let note_to_diagnostic : Driver.any_note -> Diagnostic.t = function
 
 let notes =
   D.Programs.key ~name:__MODULE__ @@ fun data prog ->
-  let tags, store = D.need data Store.linters (Node.span prog.eof).filename in
+  let tags, store = D.need data Store.linters (Node.span prog.eof |> Span.filename) in
   let notes =
     List.fold_left
       (fun notes linter ->

--- a/src/bin/lsp/lsp_convert.ml
+++ b/src/bin/lsp/lsp_convert.ml
@@ -2,16 +2,16 @@ open IlluaminateCore
 open Lsp
 open Lsp.Types
 
-let span_start { Span.start_line; start_col; _ } : Position.t =
-  { line = start_line - 1; character = start_col - 1 }
+let span_start span : Position.t =
+  { line = Span.start_line.get span - 1; character = Span.start_col.get span - 1 }
 
-let span_finish { Span.finish_line; finish_col; _ } : Position.t =
-  { line = finish_line - 1; character = finish_col }
+let span_finish span : Position.t =
+  { line = Span.finish_line.get span - 1; character = Span.finish_col.get span }
 
 let range span = Range.create ~start:(span_start span) ~end_:(span_finish span)
 
 let location (span : Span.t) =
-  Location.create ~uri:(Store.Filename.to_uri span.filename |> Uri.to_string) ~range:(range span)
+  Location.create ~uri:(Span.filename span |> Store.Filename.to_uri |> Uri.to_string) ~range:(range span)
 
 let severity : Error.level -> DiagnosticSeverity.t = function
   | Critical | Error -> Error

--- a/src/bin/lsp/lsp_convert.ml
+++ b/src/bin/lsp/lsp_convert.ml
@@ -3,10 +3,10 @@ open Lsp
 open Lsp.Types
 
 let span_start span : Position.t =
-  { line = Span.start_line.get span - 1; character = Span.start_col.get span - 1 }
+  { line = Span.start_line span - 1; character = Span.start_col.get span - 1 }
 
 let span_finish span : Position.t =
-  { line = Span.finish_line.get span - 1; character = Span.finish_col.get span }
+  { line = Span.finish_line span - 1; character = Span.finish_col.get span }
 
 let range span = Range.create ~start:(span_start span) ~end_:(span_finish span)
 

--- a/src/bin/lsp/lsp_convert.ml
+++ b/src/bin/lsp/lsp_convert.ml
@@ -11,7 +11,9 @@ let span_finish span : Position.t =
 let range span = Range.create ~start:(span_start span) ~end_:(span_finish span)
 
 let location (span : Span.t) =
-  Location.create ~uri:(Span.filename span |> Store.Filename.to_uri |> Uri.to_string) ~range:(range span)
+  Location.create
+    ~uri:(Span.filename span |> Store.Filename.to_uri |> Uri.to_string)
+    ~range:(range span)
 
 let severity : Error.level -> DiagnosticSeverity.t = function
   | Critical | Error -> Error

--- a/src/config/lexer.mll
+++ b/src/config/lexer.mll
@@ -16,44 +16,44 @@ let digit = ['0'-'9']
 let hex = ['0'-'9' 'a'-'f' 'A'-'F']
 let id = ['!' '#'-'\'' '*'-':' '<'-'~'] (* All printable characters excluding '(', ')', ';' and '"'. *)
 
-rule token = parse
+rule token l = parse
 | white+                { Skip }
-| '\n'                  { Lexing.new_line lexbuf; Skip }
+| '\n'                  { IlluaminateCore.Span.Lines.new_line l; Skip }
 | ';' [^'\n']*          { Skip }
 
 | '('                   { Open }
 | ')'                   { Close }
 | id+                   { String (Lexing.lexeme lexbuf) }
-| '\"'                  { string (Buffer.create 17) lexbuf }
+| '\"'                  { string (Buffer.create 17) l lexbuf }
 | eof                   { End }
 | _                     { raise (Error (lexeme_spanned lexbuf (Printf.sprintf "Unexpected character %S." (Lexing.lexeme lexbuf)))) }
 
-and string value = parse
+and string value l = parse
 | '\"'              { String (Buffer.contents value) }
-| '\''              { Buffer.add_char value '\'';   string value lexbuf }
+| '\''              { Buffer.add_char value '\'';   string value l lexbuf }
 
-| "\\a"             { Buffer.add_char value '\007'; string value lexbuf }
-| "\\b"             { Buffer.add_char value '\b';   string value lexbuf }
-| "\\f"             { Buffer.add_char value '\012'; string value lexbuf }
-| "\\n"             { Buffer.add_char value '\n';   string value lexbuf }
-| "\\r"             { Buffer.add_char value '\r';   string value lexbuf }
-| "\\v"             { Buffer.add_char value '\011'; string value lexbuf }
-| "\\t"             { Buffer.add_char value '\t';   string value lexbuf }
+| "\\a"             { Buffer.add_char value '\007'; string value l lexbuf }
+| "\\b"             { Buffer.add_char value '\b';   string value l lexbuf }
+| "\\f"             { Buffer.add_char value '\012'; string value l lexbuf }
+| "\\n"             { Buffer.add_char value '\n';   string value l lexbuf }
+| "\\r"             { Buffer.add_char value '\r';   string value l lexbuf }
+| "\\v"             { Buffer.add_char value '\011'; string value l lexbuf }
+| "\\t"             { Buffer.add_char value '\t';   string value l lexbuf }
 
-| "\\\\"            { Buffer.add_char value '\\';   string value lexbuf }
-| "\\\""            { Buffer.add_char value '\"';   string value lexbuf }
-| "\\\'"            { Buffer.add_char value '\'';   string value lexbuf }
+| "\\\\"            { Buffer.add_char value '\\';   string value l lexbuf }
+| "\\\""            { Buffer.add_char value '\"';   string value l lexbuf }
+| "\\\'"            { Buffer.add_char value '\'';   string value l lexbuf }
 
 | "\\x" ((hex hex?) as x)
                     { Buffer.add_char value ("0x" ^ x |> int_of_string |> char_of_int);
-                      string value lexbuf }
+                      string value l lexbuf }
 | "\\" ((digit digit? digit?) as x)
                     { Buffer.add_char value (int_of_string x |> char_of_int);
-                      string value lexbuf }
+                      string value l lexbuf }
 
 | [^'\\' '\"' '\'' '\n']+ as x
                     { Buffer.add_string value x;
-                      string value lexbuf }
+                      string value l lexbuf }
 
 | eof               { raise (Error (lexeme_spanned lexbuf "Expected '\"' at end of file.")) }
 | '\n'              { raise (Error (lexeme_spanned lexbuf "Expected '\"' at end of line.")) }

--- a/src/core/error.ml
+++ b/src/core/error.ml
@@ -189,7 +189,8 @@ let display_of_files ?(out = Format.err_formatter) ?(with_summary = true) store 
            | None -> ""
            | Some path ->
                let ch = get_channel (Fpath.to_string path) in
-               seek_in ch (Span.start_bol span); input_line ch
+               seek_in ch (Span.start_bol span);
+               input_line ch
          in
          display_line out line err);
   ( match !last with

--- a/src/core/error.ml
+++ b/src/core/error.ml
@@ -129,10 +129,15 @@ let error_ansi = function
   | Note -> Style.Blue
 
 let display_line out line { Error.tag; span; message; details } =
-  let line_no = string_of_int span.start_line in
+  let start_l = Span.start_line.get span
+  and start_c = Span.start_col.get span
+  and finish_l = Span.finish_line.get span
+  and finish_c = Span.finish_col.get span in
+  let line_no = start_l |> string_of_int in
+
   Style.(printf (BrightColor (error_ansi tag.level)))
-    out "%s:[%d:%d-%d:%d]: %s [%s]@\n" span.filename.name span.start_line span.start_col
-    span.finish_line span.finish_col message tag.name;
+    out "%s:[%d:%d-%d:%d]: %s [%s]@\n" (Span.filename span).name start_l start_c finish_l finish_c
+    message tag.name;
   ( match details with
   | None -> ()
   | Some details -> Format.fprintf out "%t@\n" details );
@@ -143,10 +148,9 @@ let display_line out line { Error.tag; span; message; details } =
   fmt "" "";
   fmt line_no (CCString.replace ~sub:"\t" ~by:" " line);
   let length =
-    if span.finish_line = span.start_line then span.finish_col - span.start_col + 1
-    else String.length line - span.start_col + 1
+    if finish_l = start_l then finish_c - start_c + 1 else String.length line - start_c + 1
   in
-  fmt "" (String.make (span.start_col - 1) ' ' ^ String.make length '^')
+  fmt "" (String.make (start_c - 1) ' ' ^ String.make length '^')
 
 let summary out t =
   let errors, warnings =
@@ -181,11 +185,11 @@ let display_of_files ?(out = Format.err_formatter) ?(with_summary = true) store 
   store
   |> each_error (fun ({ span; _ } as err) ->
          let line =
-           match span.filename.path with
+           match (Span.filename span).path with
            | None -> ""
            | Some path ->
                let ch = get_channel (Fpath.to_string path) in
-               seek_in ch span.start_bol; input_line ch
+               seek_in ch (Span.start_bol span); input_line ch
          in
          display_line out line err);
   ( match !last with
@@ -196,15 +200,16 @@ let display_of_files ?(out = Format.err_formatter) ?(with_summary = true) store 
 let display_of_string ?(out = Format.err_formatter) ?(with_summary = true) getter store =
   store
   |> each_error (fun ({ span; _ } as err) ->
-         match getter span.filename with
+         match getter (Span.filename span) with
          | None -> ()
          | Some contents ->
              let line =
-               String.sub contents span.start_bol
-                 ( ( match String.index_from_opt contents span.start_bol '\n' with
+               let bol = Span.start_bol span in
+               String.sub contents bol
+                 ( ( match String.index_from_opt contents bol '\n' with
                    | None -> String.length contents
                    | Some x -> x )
-                 - span.start_bol )
+                 - bol )
              in
              display_line out line err);
 

--- a/src/core/error.ml
+++ b/src/core/error.ml
@@ -129,9 +129,9 @@ let error_ansi = function
   | Note -> Style.Blue
 
 let display_line out line { Error.tag; span; message; details } =
-  let start_l = Span.start_line.get span
+  let start_l = Span.start_line span
   and start_c = Span.start_col.get span
-  and finish_l = Span.finish_line.get span
+  and finish_l = Span.finish_line span
   and finish_c = Span.finish_col.get span in
   let line_no = start_l |> string_of_int in
 

--- a/src/core/span.ml
+++ b/src/core/span.ml
@@ -37,11 +37,22 @@ type t =
     finish_col : int;
     finish_bol : int
   }
+[@@deriving illuaminateDeriving_lens]
+
+let filename = T.filename.get
+
+let start_line = T.start_line
+
+let start_col = T.start_col
+
+let start_bol = T.start_bol.get
+
+let finish_line = T.finish_line
+
+let finish_col = T.finish_col
 
 let pp out { filename; start_line; start_col; finish_line; finish_col; _ } =
   Format.fprintf out "%s[%d:%d-%d:%d]" filename.name start_line start_col finish_line finish_col
-
-let show = Format.asprintf "%a" pp
 
 let compare a b =
   if a.filename <> b.filename then String.compare a.filename.name b.filename.name

--- a/src/core/span.ml
+++ b/src/core/span.ml
@@ -108,11 +108,11 @@ module Lines = struct
     let line, bol = find_line ~offset lines in
     let col = offset - bol + 1 in
     let col' = f col in
-    let offset' = offset - col + col' in
-    let line', _ = find_line ~offset:offset' lines in
+    let offset' = bol + col' - 1 in
+    let line', bol' = find_line ~offset:offset' lines in
     if line' <> line then
-      Printf.sprintf "Column modification changes line (from %d=>%d:%d to %d=>%d:%d)." offset col
-        line offset' col' line'
+      Printf.sprintf "Column modification changes line, from %d=>%d(%d):%d to %d=>%d(%d):%d." offset
+        line bol col offset' line' bol' col'
       |> failwith;
     offset'
 end

--- a/src/core/span.ml
+++ b/src/core/span.ml
@@ -28,52 +28,147 @@ type filename = Filename.t =
     hash : int
   }
 
+module Lines = struct
+  module IntMap = Map.Make (Int)
+
+  type store =
+    | Array of int array
+    | Map of int IntMap.t * Lexing.lexbuf
+
+  type t =
+    { file : filename;
+      mutable store : store
+    }
+
+  let new_line = function
+    | { store = Array _; _ } -> failwith "new_line: Called after finalising"
+    | { store = Map (lines, buf); _ } as st ->
+        Lexing.new_line buf;
+        let { Lexing.pos_lnum; pos_bol; _ } = buf.lex_curr_p in
+        st.store <- Map (IntMap.add (pos_lnum - 1) pos_bol lines, buf)
+
+  let using file buf f =
+    if not (Lexing.with_positions buf) then
+      invalid_arg "using: Lexing.lexbuf should be tracking positions";
+    buf.lex_curr_p <- { buf.lex_curr_p with pos_fname = file.id };
+    let lines = { file; store = Map (IntMap.singleton 0 0, buf) } in
+
+    let res = f lines in
+
+    (* Update the backing map to an array. Should be faster to search than a tree. *)
+    match lines.store with
+    | Array _ -> failwith "using: lines has become an array"
+    | Map (xs, _) ->
+        let arr = Array.make (fst (IntMap.max_binding xs) + 1) 0 in
+        IntMap.iter (fun line pos -> arr.(line) <- pos) xs;
+        lines.store <- Array arr;
+        res
+
+  let find ~offset idx =
+    let rec go start finish =
+      if start = finish then (start, idx start)
+      else
+        (* If our offset occurs before the start of the current line, search before there. *)
+        let mid = (start + finish + 1) / 2 in
+        if offset < idx mid then go start (mid - 1) else go mid finish
+    in
+    fun s f -> go s f
+
+  let find_line ~offset = function
+    | _ when offset <= 0 -> (0, 0)
+    | { store = Array xs; _ } -> find ~offset (Array.get xs) 0 (Array.length xs - 1)
+    | { store = Map (xs, _); _ } ->
+        find ~offset (Fun.flip IntMap.find xs) 0 (IntMap.max_binding xs |> fst)
+
+  let find_offset ~line = function
+    | { store = Array xs; _ } ->
+        let len = Array.length xs in
+        if line < 0 then 0 else if line >= len then xs.(len - 1) else xs.(line)
+    | { store = Map (xs, _); _ } -> (
+        if line < 0 then 0
+        else
+          match IntMap.find_opt line xs with
+          | Some l -> l
+          | None -> IntMap.max_binding xs |> snd )
+
+  let get_line lines offset =
+    let line, _ = find_line ~offset lines in
+    line + 1
+
+  let get_col lines offset =
+    let _, bol = find_line ~offset lines in
+    offset - bol + 1
+
+  let over_line f lines offset =
+    let line, bol = find_line ~offset lines in
+    let line = f (line + 1) - 1 in
+    find_offset ~line lines + (offset - bol)
+
+  let over_col f lines offset =
+    let line, bol = find_line ~offset lines in
+    let col = offset - bol + 1 in
+    let col' = f col in
+    let offset' = offset - col + col' in
+    let line', _ = find_line ~offset:offset' lines in
+    if line' <> line then
+      Printf.sprintf "Column modification changes line (from %d=>%d:%d to %d=>%d:%d)." offset col
+        line offset' col' line'
+      |> failwith;
+    offset'
+end
+
 type t =
-  { filename : filename;
-    start_line : int;
-    start_col : int;
-    start_bol : int;
-    finish_line : int;
-    finish_col : int;
-    finish_bol : int
+  { lines : Lines.t;
+    start : int;
+    finish : int
   }
-[@@deriving illuaminateDeriving_lens]
 
-let filename = T.filename.get
+let filename x = x.lines.file
 
-let start_line = T.start_line
+let start_line =
+  { Lens.get = (fun { lines; start; _ } -> Lines.get_line lines start);
+    over = (fun f ({ lines; start; _ } as l) -> { l with start = Lines.over_line f lines start })
+  }
 
-let start_col = T.start_col
+let start_col =
+  { Lens.get = (fun { lines; start; _ } -> Lines.get_col lines start);
+    over = (fun f ({ lines; start; _ } as l) -> { l with start = Lines.over_col f lines start })
+  }
 
-let start_bol = T.start_bol.get
+let start_bol { lines; start; _ } = Lines.find_line ~offset:start lines |> snd
 
-let finish_line = T.finish_line
+let finish_line =
+  { Lens.get = (fun { lines; finish; _ } -> Lines.get_line lines finish);
+    over = (fun f ({ lines; finish; _ } as l) -> { l with finish = Lines.over_line f lines finish })
+  }
 
-let finish_col = T.finish_col
+let finish_col =
+  { Lens.get = (fun { lines; finish; _ } -> Lines.get_col lines finish);
+    over = (fun f ({ lines; finish; _ } as l) -> { l with finish = Lines.over_col f lines finish })
+  }
 
-let pp out { filename; start_line; start_col; finish_line; finish_col; _ } =
-  Format.fprintf out "%s[%d:%d-%d:%d]" filename.name start_line start_col finish_line finish_col
+let pp out span =
+  Format.fprintf out "%s[%d:%d-%d:%d]" (filename span).name (start_line.get span)
+    (start_col.get span) (finish_line.get span) (finish_col.get span)
+
+let show = Format.asprintf "%a" pp
 
 let compare a b =
-  if a.filename <> b.filename then String.compare a.filename.name b.filename.name
-  else Int.compare (a.start_col + a.start_bol) (b.start_col + b.start_bol)
+  if a.lines.file <> b.lines.file then Filename.compare a.lines.file b.lines.file
+  else if a.start <> b.start then Int.compare a.start b.start
+  else Int.compare a.finish b.finish
 
-let of_pos2 filename (start : Lexing.position) (fin : Lexing.position) =
-  { filename;
-    start_line = start.pos_lnum;
-    start_col = start.pos_cnum - start.pos_bol + 1;
-    start_bol = start.pos_bol;
-    finish_line = fin.pos_lnum;
-    finish_col = fin.pos_cnum - fin.pos_bol;
-    finish_bol = fin.pos_bol
+let of_pos2 lines (start : Lexing.position) (fin : Lexing.position) =
+  { lines;
+    start = start.pos_cnum;
+    (* The [fin] will /generally/ be one after our actual finish position, thus we decrement it by
+       one. However, we need to special-case eof, as that's a 0-width token.*)
+    finish = (if fin.pos_cnum <= start.pos_cnum then start.pos_cnum else fin.pos_cnum - 1)
   }
 
-let of_span2 { filename; start_line; start_col; start_bol; _ }
-    { finish_line; finish_col; finish_bol; _ } =
-  { filename; start_line; start_col; start_bol; finish_line; finish_col; finish_bol }
+let of_span2 { lines; start; _ } { finish; _ } = { lines; start; finish }
 
-let finish s =
-  { s with start_line = s.finish_line; start_col = s.finish_col; start_bol = s.finish_bol }
+let finish s = { s with start = s.finish }
 
 type 'a spanned =
   { value : 'a;

--- a/src/core/span.mli
+++ b/src/core/span.mli
@@ -48,20 +48,26 @@ type t
 (** Get the filename for this span. *)
 val filename : t -> filename
 
-(** A lens over the starting line of this span. *)
-val start_line : (t, int) Lens.lens'
-
-(** A lens over the starting column of this span. *)
-val start_col : (t, int) Lens.lens'
+(** Get the start line of this span.*)
+val start_line : t -> int
 
 (** Get the beginning of the starting line for this span. *)
 val start_bol : t -> int
 
-(** A lens over the last column of this span. *)
-val finish_line : (t, int) Lens.lens'
+(** A lens over the starting column of this span. *)
+val start_col : (t, int) Lens.lens'
 
-(** A lens over the last line of this span. *)
+(** A lens over the starting line and column of this span. *)
+val start_pos : (t, int * int) Lens.lens'
+
+(** Get the end line this span. *)
+val finish_line : t -> int
+
+(** A lens over the end column of this span. *)
 val finish_col : (t, int) Lens.lens'
+
+(** A lens over the end line and column of this span. *)
+val finish_pos : (t, int * int) Lens.lens'
 
 val show : t -> string
 

--- a/src/core/span.mli
+++ b/src/core/span.mli
@@ -29,6 +29,19 @@ type filename = Filename.t = private
     hash : int
   }
 
+(** A builder, which tracks the start position of newlines, allowing you to map between the two. *)
+module Lines : sig
+  type t
+
+  (** Lex using this line builder. This sets up the lexer with the appropriate positions and then
+      passes the lines builder to the given lexing/parsing function. This object may then be used to
+      construct positions, using {!of_pos2}. *)
+  val using : filename -> Lexing.lexbuf -> (t -> 'a) -> 'a
+
+  (** Wraps {!Lexing.new_line}, also tracking it within the context. *)
+  val new_line : t -> unit
+end
+
 (** A span in a file or other source program *)
 type t
 
@@ -50,13 +63,15 @@ val finish_line : (t, int) Lens.lens'
 (** A lens over the last line of this span. *)
 val finish_col : (t, int) Lens.lens'
 
+val show : t -> string
+
 val pp : Format.formatter -> t -> unit
 
 (** Compare two spans given their filename and position in the file. *)
 val compare : t -> t -> int
 
 (** Make a source span from a pair of lexing positions *)
-val of_pos2 : filename -> Lexing.position -> Lexing.position -> t
+val of_pos2 : Lines.t -> Lexing.position -> Lexing.position -> t
 
 (** Make a source span from a pair of two other spans *)
 val of_span2 : t -> t -> t

--- a/src/core/span.mli
+++ b/src/core/span.mli
@@ -30,17 +30,25 @@ type filename = Filename.t = private
   }
 
 (** A span in a file or other source program *)
-type t =
-  { filename : filename;
-    start_line : int;
-    start_col : int;
-    start_bol : int;
-    finish_line : int;
-    finish_col : int;
-    finish_bol : int
-  }
+type t
 
-val show : t -> string
+(** Get the filename for this span. *)
+val filename : t -> filename
+
+(** A lens over the starting line of this span. *)
+val start_line : (t, int) Lens.lens'
+
+(** A lens over the starting column of this span. *)
+val start_col : (t, int) Lens.lens'
+
+(** Get the beginning of the starting line for this span. *)
+val start_bol : t -> int
+
+(** A lens over the last column of this span. *)
+val finish_line : (t, int) Lens.lens'
+
+(** A lens over the last line of this span. *)
+val finish_col : (t, int) Lens.lens'
 
 val pp : Format.formatter -> t -> unit
 

--- a/src/lint/lint_pcall_eta.ml
+++ b/src/lint/lint_pcall_eta.ml
@@ -68,7 +68,7 @@ let linter =
               }
         }
       when let span = Spanned.call (Call call) in
-           Span.(start_line.get span = finish_line.get span) ->
+           Span.(start_line span = finish_line span) ->
         let args = Helpers.get_call_args call.args in
         let args =
           match args with

--- a/src/lint/lint_pcall_eta.ml
+++ b/src/lint/lint_pcall_eta.ml
@@ -68,7 +68,7 @@ let linter =
               }
         }
       when let span = Spanned.call (Call call) in
-           span.start_line = span.finish_line ->
+           Span.(start_line.get span = finish_line.get span) ->
         let args = Helpers.get_call_args call.args in
         let args =
           match args with

--- a/src/lint/lint_spacing.ml
+++ b/src/lint/lint_spacing.ml
@@ -18,7 +18,7 @@ let has_trailing = function
 let has_leading prev = function
   | Node.SimpleNode _ -> true
   | Node.Node { leading_trivia; span; _ } ->
-      span.start_col = 1
+      Span.start_col.get span = 1
       || ( match CCList.last_opt leading_trivia with
          | Some { value = Whitespace ws; _ } when String.length ws > 0 -> true
          | _ -> false )

--- a/src/lint/lint_table_trailing.ml
+++ b/src/lint/lint_table_trailing.ml
@@ -84,7 +84,7 @@ let linter =
     | Table
         { table_open = Node { span = start; _ }; table_body; table_close = Node { span = fin; _ } }
       -> (
-        let multiline = start.start_line <> fin.start_line in
+        let multiline = Span.start_line.get start <> Span.start_line.get fin in
         match CCList.last_opt table_body with
         | None -> [] (* If it's an empty table, allow both. *)
         | Some (item, None) when multiline ->

--- a/src/lint/lint_table_trailing.ml
+++ b/src/lint/lint_table_trailing.ml
@@ -84,7 +84,7 @@ let linter =
     | Table
         { table_open = Node { span = start; _ }; table_body; table_close = Node { span = fin; _ } }
       -> (
-        let multiline = Span.start_line.get start <> Span.start_line.get fin in
+        let multiline = Span.start_line start <> Span.start_line fin in
         match CCList.last_opt table_body with
         | None -> [] (* If it's an empty table, allow both. *)
         | Some (item, None) when multiline ->

--- a/src/parser/illuaminateParser.ml
+++ b/src/parser/illuaminateParser.ml
@@ -20,8 +20,8 @@ let lex_leading file lexbuf =
 let lex_trailing file lexbuf tok_span =
   let rec go xs =
     match lex_one file lexbuf with
-    | { Span.value = Trivial value; span = { start_line; _ } as span }
-      when start_line = tok_span.Span.start_line ->
+    | { Span.value = Trivial value; span }
+      when Span.start_line.get span = Span.start_line.get tok_span ->
         go ({ Span.value; span } :: xs)
     | t -> (List.rev xs, t)
   in

--- a/src/semantics/doc_extract.ml
+++ b/src/semantics/doc_extract.ml
@@ -206,23 +206,23 @@ module Infer = struct
   let documenting state ~before ~after (span : Span.t) value : value documented =
     (* Limit comments to ones directly before/after the current node and appropriately aligned with
        it. *)
-    let start_line = Span.start_line.get span
-    and finish_line = Span.finish_line.get span
+    let start_line = Span.start_line span
+    and finish_line = Span.finish_line span
     and start_col = Span.start_col.get span in
     let before =
       match before with
       | ({ C.source; _ } as c) :: _
-        when Span.start_line.get source = start_line
-             || Span.finish_line.get source = start_line - 1
-                && Span.start_col.get source = start_col ->
+        when Span.start_line source = start_line
+             || (Span.finish_line source = start_line - 1 && Span.start_col.get source = start_col)
+        ->
           Some c
       | _ -> None
     and after =
       match after with
       | ({ C.source; _ } as c) :: _
-        when Span.finish_line.get source = finish_line
-             || Span.start_line.get source = finish_line + 1
-                && Span.start_col.get source = start_col ->
+        when Span.finish_line source = finish_line
+             || (Span.start_line source = finish_line + 1 && Span.start_col.get source = start_col)
+        ->
           Some c
       | _ -> None
     in
@@ -480,7 +480,7 @@ module Infer = struct
       match P.comment (First.program.get program) state.comments |> fst |> CCList.last_opt with
       | Some ({ source; _ } as c)
         when Span.start_col.get source = 1
-             && Span.start_line.get source = 1
+             && Span.start_line source = 1
              && CommentCollection.mem state.unused_comments c ->
           CommentCollection.remove state.unused_comments c;
           Some c

--- a/src/semantics/doc_extract.ml
+++ b/src/semantics/doc_extract.ml
@@ -206,18 +206,23 @@ module Infer = struct
   let documenting state ~before ~after (span : Span.t) value : value documented =
     (* Limit comments to ones directly before/after the current node and appropriately aligned with
        it. *)
+    let start_line = Span.start_line.get span
+    and finish_line = Span.finish_line.get span
+    and start_col = Span.start_col.get span in
     let before =
       match before with
       | ({ C.source; _ } as c) :: _
-        when source.start_line = span.start_line
-             || (source.finish_line = span.start_line - 1 && source.start_col = span.start_col) ->
+        when Span.start_line.get source = start_line
+             || Span.finish_line.get source = start_line - 1
+                && Span.start_col.get source = start_col ->
           Some c
       | _ -> None
     and after =
       match after with
       | ({ C.source; _ } as c) :: _
-        when source.finish_line = span.finish_line
-             || (source.start_line = span.finish_line + 1 && source.start_col = span.start_col) ->
+        when Span.finish_line.get source = finish_line
+             || Span.start_line.get source = finish_line + 1
+                && Span.start_col.get source = start_col ->
           Some c
       | _ -> None
     in
@@ -474,7 +479,8 @@ module Infer = struct
     let module_comment =
       match P.comment (First.program.get program) state.comments |> fst |> CCList.last_opt with
       | Some ({ source; _ } as c)
-        when source.start_col = 1 && source.start_line = 1
+        when Span.start_col.get source = 1
+             && Span.start_line.get source = 1
              && CommentCollection.mem state.unused_comments c ->
           CommentCollection.remove state.unused_comments c;
           Some c
@@ -491,8 +497,9 @@ module Infer = struct
           Named (Value.get_documented ~state comment |> Merge.documented merge body)
       | Some ({ module_info = None; _ } as comment) ->
           let body = Value.get_documented ~state comment |> Merge.doc_value ~errs:state.errs body in
-          Unnamed { body; mod_types; file = (Spanned.program program).filename; mod_kind }
-      | None -> Unnamed { body; mod_types; file = (Spanned.program program).filename; mod_kind }
+          Unnamed { body; mod_types; file = Spanned.program program |> Span.filename; mod_kind }
+      | None ->
+          Unnamed { body; mod_types; file = Spanned.program program |> Span.filename; mod_kind }
     in
     (state, result)
 
@@ -733,7 +740,7 @@ let detached_comments ({ comments; _ } : t) = CommentCollection.to_seq_keys comm
 
 let get_unresolved_module data program =
   let module_path =
-    D.need data D.Programs.Context.key (Spanned.program program).filename |> Config.get
+    D.need data D.Programs.Context.key (Spanned.program program |> Span.filename) |> Config.get
   in
   match D.need data Infer.key program |> snd with
   | Named m -> Some m

--- a/src/semantics/doc_parser.ml
+++ b/src/semantics/doc_parser.ml
@@ -100,7 +100,7 @@ let match_string terminate str start =
     else
       match (str.[pos], closes) with
       (* Close bracket *)
-      | x, c :: cs when x == c -> worker (pos + 1) cs
+      | x, c :: cs when x = c -> worker (pos + 1) cs
       | '(', _ -> worker (pos + 1) (')' :: closes)
       | '{', _ -> worker (pos + 1) ('}' :: closes)
       | '[', _ -> worker (pos + 1) (']' :: closes)
@@ -456,11 +456,11 @@ let extract node =
         (* Skip whitespace *)
         extract_block buffer last line column xs
     | { Span.value = Node.LineComment c; span } :: xs
-      when Span.start_line.get span = line + 1 && Span.start_col.get span = column ->
+      when Span.start_line span = line + 1 && Span.start_col.get span = column ->
         (* Comments aligned with this one on successive lines are included *)
         Buffer.add_char buffer '\n';
         add_trimmed buffer c 0;
-        extract_block buffer span (Span.start_line.get span) column xs
+        extract_block buffer span (Span.start_line span) column xs
     | xs -> (last, xs)
   in
   (* Extract all comments before this token *)
@@ -478,7 +478,7 @@ let extract node =
         let buffer = Buffer.create 16 in
         Buffer.add_substring buffer c 1 (String.length c - 1);
         let last, xs =
-          extract_block buffer span (Span.start_line.get span) (Span.start_col.get span) xs
+          extract_block buffer span (Span.start_line span) (Span.start_col.get span) xs
         in
         let documented = Buffer.contents buffer |> parse |> build (Span.of_span2 span last) in
         extract_comments (documented :: cs) xs

--- a/src/semantics/string_escape.mll
+++ b/src/semantics/string_escape.mll
@@ -9,10 +9,10 @@ type component =
   | Quote of char
 
 let pos (span : Span.t) lexbuf =
-  { span with
-    start_col = span.start_col + (Lexing.lexeme_start_p lexbuf).pos_cnum;
-    finish_col = span.start_col + (Lexing.lexeme_end_p lexbuf).pos_cnum - 1
-  }
+  let open Lens in
+  span
+  |> (Span.start_col ^= (Span.start_col.get span + (Lexing.lexeme_start_p lexbuf).pos_cnum))
+     % (Span.finish_col ^= (Span.start_col.get span + (Lexing.lexeme_end_p lexbuf).pos_cnum - 1))
 
 }
 

--- a/src/web/template.re
+++ b/src/web/template.re
@@ -37,9 +37,9 @@ let partition_string = (start, length, str) => {
 };
 
 let error = (line, ~fix=?, {Error.Error.span, message, tag, _}) => {
-  let start_line = Span.start_line.get(span);
+  let start_line = Span.start_line(span);
   let start_col = Span.start_col.get(span);
-  let finish_line = Span.finish_line.get(span);
+  let finish_line = Span.finish_line(span);
   let finish_col = Span.finish_col.get(span);
 
   let length =

--- a/test/data/parser/pass_binop.out
+++ b/test/data/parser/pass_binop.out
@@ -73,7 +73,7 @@
                             Node.Node {leading_trivia = [];
                               trailing_trivia =
                               [{ Span.value = (Node.Whitespace "\n");
-                                 span = pass_binop.lua[1:20-2:0] }
+                                 span = pass_binop.lua[1:20-1:20] }
                                 ];
                               contents = "4";
                               span = pass_binop.lua[1:19-1:19]}
@@ -83,5 +83,5 @@
     ];
   eof =
   Node.Node {leading_trivia = []; trailing_trivia = [];
-    contents = end of file; span = pass_binop.lua[2:1-2:0]}
+    contents = end of file; span = pass_binop.lua[2:1-2:1]}
   }

--- a/test/data/parser/pass_multiline_string.out
+++ b/test/data/parser/pass_multiline_string.out
@@ -6,15 +6,15 @@
           [{ Span.value = (Node.BlockComment (0, " One line "));
              span = pass_multiline_string.lua[1:1-1:16] };
             { Span.value = (Node.Whitespace "\n");
-              span = pass_multiline_string.lua[1:17-2:0] };
+              span = pass_multiline_string.lua[1:17-1:17] };
             { Span.value = (Node.Whitespace "\n");
-              span = pass_multiline_string.lua[2:1-3:0] };
+              span = pass_multiline_string.lua[2:1-2:1] };
             { Span.value = (Node.BlockComment (0, "\nMulti-line\n"));
               span = pass_multiline_string.lua[3:1-5:2] };
             { Span.value = (Node.Whitespace "\n");
-              span = pass_multiline_string.lua[5:3-6:0] };
+              span = pass_multiline_string.lua[5:3-5:3] };
             { Span.value = (Node.Whitespace "\n");
-              span = pass_multiline_string.lua[6:1-7:0] }
+              span = pass_multiline_string.lua[6:1-6:1] }
             ];
           trailing_trivia =
           [{ Span.value = (Node.Whitespace " ");
@@ -44,7 +44,7 @@
                        Node.Node {leading_trivia = [];
                          trailing_trivia =
                          [{ Span.value = (Node.Whitespace "\n");
-                            span = pass_multiline_string.lua[7:25-8:0] }
+                            span = pass_multiline_string.lua[7:25-7:25] }
                            ];
                          contents = "[[ One line ]]";
                          span = pass_multiline_string.lua[7:11-7:24]}
@@ -88,8 +88,8 @@
   Node.Node {
     leading_trivia =
     [{ Span.value = (Node.Whitespace "\n");
-       span = pass_multiline_string.lua[12:4-13:0] }
+       span = pass_multiline_string.lua[12:4-12:4] }
       ];
     trailing_trivia = []; contents = end of file;
-    span = pass_multiline_string.lua[13:1-13:0]}
+    span = pass_multiline_string.lua[13:1-13:1]}
   }

--- a/test/data/parser/pass_simple.out
+++ b/test/data/parser/pass_simple.out
@@ -55,12 +55,12 @@
                     { Span.value = (Node.LineComment "- @local");
                       span = pass_simple.lua[1:29-1:38] };
                     { Span.value = (Node.Whitespace "\n");
-                      span = pass_simple.lua[1:39-2:0] }
+                      span = pass_simple.lua[1:39-1:39] }
                     ];
                   contents = "enter"; span = pass_simple.lua[1:23-1:27]}}))
         })
     ];
   eof =
   Node.Node {leading_trivia = []; trailing_trivia = [];
-    contents = end of file; span = pass_simple.lua[2:1-2:0]}
+    contents = end of file; span = pass_simple.lua[2:1-2:1]}
   }

--- a/test/dune
+++ b/test/dune
@@ -1,10 +1,11 @@
 (test
  (name test)
  (libraries omnomnom omnomnom.golden omnomnom.junit omnomnom.alcotest
-   containers containers.sexp illuaminate.core illuaminate.config
-   illuaminate.data illuaminate.parser illuaminate.lint omd fpath
-   illuaminate.semantics illuaminate.pattern illuaminateLsp lsp lsp.stdune
-   logs cmdliner yojson result alcotest fmt ppx_yojson_conv_lib)
+   omnomnom.qcheck containers containers.sexp illuaminate.core
+   illuaminate.config illuaminate.data illuaminate.parser illuaminate.lint
+   omd fpath illuaminate.semantics illuaminate.pattern illuaminateLsp lsp
+   lsp.stdune logs cmdliner yojson result alcotest fmt ppx_yojson_conv_lib
+   qcheck-core)
  (variants unix)
  (deps
   (source_tree data))

--- a/test/span.ml
+++ b/test/span.ml
@@ -1,0 +1,35 @@
+open IlluaminateCore
+open Lens
+open Span
+open Omnomnom.Tests
+open OmnomnomQCheck
+
+let gen_position =
+  QCheck.(list (int_bound 100))
+  |> QCheck.map_keep_input @@ fun offsets ->
+     let buf = Lexing.from_string "" in
+     Lines.using (Filename.mk "=") buf @@ fun l ->
+     List.fold_left
+       (fun (line, bol) offset ->
+         let bol = bol + offset + 1 in
+         buf.lex_curr_p <- { buf.lex_curr_p with pos_cnum = bol; pos_lnum = line };
+         Lines.new_line l;
+         (line + 1, bol))
+       (1, 0) offsets
+     |> ignore;
+
+     of_pos2 l
+       { pos_bol = 0; pos_lnum = 1; pos_cnum = 0; pos_fname = "" }
+       { pos_bol = 0; pos_lnum = 1; pos_cnum = 1; pos_fname = "" }
+
+let tests =
+  let change lens (xs, pos) =
+    QCheck.assume (xs <> [] && List.hd xs <> 0);
+    (pos |> lens %= ( + ) 1) ^. lens = (pos ^. lens) + 1
+  in
+  [ QCheck.Test.make ~count:1000 ~name:"Modifying start line" gen_position (change start_line);
+    QCheck.Test.make ~count:1000 ~name:"Modifying start column" gen_position (change start_col);
+    QCheck.Test.make ~count:1000 ~name:"Modifying finish line" gen_position (change finish_line);
+    QCheck.Test.make ~count:1000 ~name:"Modifying finish column" gen_position (change finish_col)
+  ]
+  |> List.map of_qcheck |> group "Spans"

--- a/test/span.ml
+++ b/test/span.ml
@@ -4,38 +4,74 @@ open Span
 open Omnomnom.Tests
 open OmnomnomQCheck
 
+let build lines ~start ~finish =
+  let buf = Lexing.from_string "" in
+  Lines.using (Filename.mk "=") buf @@ fun l ->
+  Array.fold_left
+    (fun (line, bol) offset ->
+      let bol = bol + offset + 1 in
+      buf.lex_curr_p <- { buf.lex_curr_p with pos_cnum = bol; pos_lnum = line };
+      Lines.new_line l;
+      (line + 1, bol))
+    (1, 0) lines
+  |> ignore;
+
+  of_pos2 l start finish
+
+let build' lines ~line ~col =
+  build lines
+    ~start:{ pos_bol = 0; pos_lnum = 1; pos_cnum = 1; pos_fname = "" }
+    ~finish:{ pos_bol = 0; pos_lnum = 1; pos_cnum = 2; pos_fname = "" }
+  |> start_pos ^= (line, col)
+  |> finish_pos ^= (line, col)
+
 let gen_position =
-  QCheck.(list (int_bound 100))
-  |> QCheck.map_keep_input @@ fun offsets ->
-     let buf = Lexing.from_string "" in
-     Lines.using (Filename.mk "=") buf @@ fun l ->
-     List.fold_left
-       (fun (line, bol) offset ->
-         let bol = bol + offset + 1 in
-         buf.lex_curr_p <- { buf.lex_curr_p with pos_cnum = bol; pos_lnum = line };
-         Lines.new_line l;
-         (line + 1, bol))
-       (1, 0) offsets
-     |> ignore;
+  QCheck.(array_of_size (Gen.pure 2) (int_bound 100))
+  |> QCheck.map_keep_input @@ fun lines ->
+     build lines
+       ~start:{ pos_bol = 0; pos_lnum = 1; pos_cnum = 0; pos_fname = "" }
+       ~finish:{ pos_bol = 0; pos_lnum = 1; pos_cnum = 1; pos_fname = "" }
 
-     of_pos2 l
-       { pos_bol = 0; pos_lnum = 1; pos_cnum = 0; pos_fname = "" }
-       { pos_bol = 0; pos_lnum = 1; pos_cnum = 1; pos_fname = "" }
-
-let tests =
+let quickcheck =
   let incr_self lens (xs, pos) =
-    QCheck.assume (xs <> [] && List.hd xs <> 0);
+    QCheck.assume (xs.(0) <> 0);
     (pos |> lens %= ( + ) 1) ^. lens = (pos ^. lens) + 1
   and incr_other lens other (xs, pos) =
-    QCheck.assume (xs <> [] && List.hd xs <> 0);
+    QCheck.assume (xs.(0) <> 0);
     (pos |> lens %= ( + ) 1) ^. other = pos ^. other
   in
   let mk ~name ?count = QCheck.Test.make ~name ?count gen_position in
-  [ mk ~count:1000 ~name:"Can increment start line" (incr_self start_line);
+  [ mk ~count:1000 ~name:"Can increment start line" (incr_self (start_pos -| Lenses.fst));
     mk ~count:1000 ~name:"Can increment start column" (incr_self start_col);
-    mk ~count:1000 ~name:"Can increment finish line" (incr_self finish_line);
+    mk ~count:1000 ~name:"Can increment finish line" (incr_self (finish_pos -| Lenses.fst));
     mk ~count:1000 ~name:"Can increment finish column" (incr_self finish_col);
-    mk ~count:1000 ~name:"Changing line preserves column" (incr_other start_line start_col);
-    mk ~count:1000 ~name:"Changing column preserves line" (incr_other start_col start_line)
+    mk ~count:1000 ~name:"Changing line preserves column"
+      (incr_other (start_pos -| Lenses.fst) start_col);
+    mk ~count:1000 ~name:"Changing column preserves line"
+      (incr_other start_col (start_pos -| Lenses.fst));
+    (* A couple of tests to verify that position bounds checks work. *)
+    QCheck.Test.make ~count:1000 ~name:"Can change column within bounds"
+      QCheck.(pair small_int small_signed_int)
+      (fun (len, col) ->
+        let in_bounds = col > 0 && col <= len + 1
+        and ok =
+          match build' [| len |] ~line:1 ~col with
+          | _ -> true
+          | exception Invalid_argument _ -> false
+        in
+        in_bounds = ok);
+    QCheck.Test.make ~count:1000 ~name:"Can change line within bounds"
+      QCheck.(pair small_int small_signed_int)
+      (fun (len, line) ->
+        let len = len + 1 in
+        let in_bounds = line > 0 && line <= len
+        and ok =
+          match build' (Array.make len 1) ~line ~col:1 with
+          | _ -> true
+          | exception Invalid_argument _ -> false
+        in
+        in_bounds = ok)
   ]
-  |> List.map of_qcheck |> group "Spans"
+  |> List.map of_qcheck |> group "Span"
+
+let tests = group "Span" [ quickcheck ]

--- a/test/span.mli
+++ b/test/span.mli
@@ -1,0 +1,1 @@
+val tests : Omnomnom.Tests.test Omnomnom.Tests.tree

--- a/test/test.ml
+++ b/test/test.ml
@@ -41,6 +41,7 @@ let () =
          Pattern.tests;
          Reprint.tests;
          Data.tests;
+         Span.tests;
          group "Documentation" [ Doc_parser.tests; Doc_extract.tests ];
          group "Language server"
            [ Lsp_diagnostic.tests;


### PR DESCRIPTION
This hides and rewrites the internal representation of spans. See 7bc4a80d56120d4bad0c9ee5a2e143f33bbcc5b7 for a full explanation and motivation.

I'm not 100% sure if this is the correct route to go yet. I might have a stab at rewriting the documentation lexer and trying to track positions using this. See if it improves things at all.